### PR TITLE
Add variance stabilizing transformation of RTX RNA-seq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ rituximab/quants/
 rituximab/Homo_sapiens.GRCh38.92.gtf
 rituximab/Homo_sapiens.GRCh38.92.sqlite
 
+# rituximab files
 rituximab/sample_list.txt
 rituximab/tximport.RDS
-
+rituximab/select_covariates.tsv
+rituximab/VST_design.pcl
+rituximab/VST_blind.pcl

--- a/rituximab/03-tximport.R
+++ b/rituximab/03-tximport.R
@@ -1,5 +1,6 @@
 # J. Taroni 2018
 # Summarize data to the gene-level with tximport
+# USAGE (from rituximab/): Rscript 03-tximport.R
 
 library(ensembldb)
 

--- a/rituximab/04-transformation.R
+++ b/rituximab/04-transformation.R
@@ -1,0 +1,48 @@
+# J. Taroni 2018
+# Transform RNA-seq data processed with Salmon + tximport with DESeq2
+# USAGE (from rituximab/): Rscript 04-transformation.R
+#
+
+# tximport output
+tximport.object <- "tximport.RDS"
+gene.summary <- readRDS(tximport.object)
+
+# read in select covariates 
+covariates.df <- data.frame(readr::read_tsv("select_covariates.tsv"))
+
+# sample names as rownames
+fastq.sample.names <- readr::read_tsv("sample_list.txt",
+                                      col_names = FALSE)
+rownames(covariates.df) <- fastq.sample.names[[1]]
+covariates.df$mainclass[which(covariates.df$comb_class == "ITN_required")] <-
+  "ITN_required"
+
+# get DESeqDataSet - w/ and w/o experimental design info
+dds <- DESeq2::DESeqDataSetFromTximport(txi = gene.summary,
+                                        colData = covariates.df,
+                                        design = ~ procbatch + timepoint + 
+                                          mainclass)
+dds.blind <- DESeq2::DESeqDataSetFromTximport(txi = gene.summary,
+                                              colData = covariates.df,
+                                              design = ~ 1)
+
+# variance stabilizing transformation - w/ and w/o experimental design taken
+# into account
+vst.design <- DESeq2::vst(object = dds, blind = FALSE)
+vst.blind <- DESeq2::vst(object = dds.blind, blind = TRUE)
+
+# extract and write transformed data to file
+# with experimental design information
+vst.design.assay <- SummarizedExperiment::assay(vst.design)
+# we'd like to keep this as a matrix in order to keep the column names as is
+vst.design.assay <- cbind(rownames(vst.design.assay), vst.design.assay)
+colnames(vst.design.assay)[1] <- "Gene"
+write.table(vst.design.assay, "VST_design.pcl", row.names = FALSE, 
+            quote = FALSE, sep = "\t")
+
+# blinded to experimental design
+vst.blind.assay <- SummarizedExperiment::assay(vst.blind)
+vst.blind.assay <- cbind(rownames(vst.blind.assay), vst.blind.assay)
+colnames(vst.blind.assay)[1] <- "Gene"
+write.table(vst.blind.assay, "VST_blind.pcl", row.names = FALSE, 
+            quote = FALSE, sep = "\t")


### PR DESCRIPTION
I intend to use VST gene-level data for supervised ML tasks. The [DESeq2 vignette](https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#data-transformations-and-visualization) (Love, Anders, and Huber. 2018) notes that transformed data are useful for tasks such as visualization and clustering. I use the `jtaroni/summarize_tx:3.4.3` Docker image for this.